### PR TITLE
Add functionality for overriding currency signs by country

### DIFF
--- a/djmoney/templatetags/djmoney.py
+++ b/djmoney/templatetags/djmoney.py
@@ -27,8 +27,6 @@ class MoneyLocalizeNode(template.Node):
         self.use_l10n = use_l10n
         self.var_name = var_name
 
-        self.request = None
-
         self.request = template.Variable('request')
         self.country_code = None
 

--- a/djmoney/templatetags/djmoney.py
+++ b/djmoney/templatetags/djmoney.py
@@ -1,5 +1,7 @@
+import importlib
 from django import template
-from django.template import TemplateSyntaxError
+from django.conf import settings
+from django.template import TemplateSyntaxError, VariableDoesNotExist
 from moneyed import Money
 
 from ..models.fields import MoneyPatched
@@ -24,6 +26,11 @@ class MoneyLocalizeNode(template.Node):
         self.currency = currency
         self.use_l10n = use_l10n
         self.var_name = var_name
+
+        self.request = None
+
+        self.request = template.Variable('request')
+        self.country_code = None
 
     @classmethod
     def handle_token(cls, parser, token):
@@ -70,6 +77,12 @@ class MoneyLocalizeNode(template.Node):
         amount = self.amount.resolve(context) if self.amount else None
         currency = self.currency.resolve(context) if self.currency else None
 
+        try:
+            self.country_code = self.request.resolve(context).country_code if self.request else None
+        except VariableDoesNotExist:
+            self.country_code = None
+
+
         if money is not None:
             if isinstance(money, Money):
                 money = MoneyPatched._patch_to_current_class(money)
@@ -86,11 +99,26 @@ class MoneyLocalizeNode(template.Node):
         money.use_l10n = self.use_l10n
 
         if self.var_name is None:
-            return money
+            return self._str_override_currency_sign(money)
 
         # as <var_name>
         context[self.var_name.token] = money
+
         return ''
+
+    def _str_override_currency_sign(self, money):
+        str_money = unicode(money)
+        if hasattr(settings, 'CURRENCY_CONFIG_MODULE'):
+            currency_config = importlib.import_module(settings.CURRENCY_CONFIG_MODULE)
+            overrides = currency_config.override_currency_by_location
+
+            if self.country_code and self.country_code.upper() in overrides.keys():
+                currencies = overrides.get(self.country_code)
+                if currencies and str(money.currency) in currencies.keys():
+                    values = currencies[str(money.currency)]
+                    str_money = str(money).replace(values[0], values[1])
+
+        return str_money
 
 
 @register.tag

--- a/djmoney/tests/tags_tests.py
+++ b/djmoney/tests/tags_tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django import template
 from django.utils import translation
+from mock import Mock
 
 from ..models.fields import MoneyPatched
 from moneyed import Money
@@ -107,3 +108,12 @@ class MoneyLocalizeTestCase(TestCase):
             '{% load djmoney %}{% money_localize amount currency %}',
             '2,60 zł',
             context={'amount': 2.6, 'currency': 'PLN'})
+
+    def testOverrideCurrencySign(self):
+        request = Mock()
+        request.country_code = 'HU'
+        with self.settings(CURRENCY_CONFIG_MODULE='djmoney.tests.test_settings'):
+            self.assertTemplate(
+                '{% load djmoney %}{% money_localize "2.5" "USD" %}',
+                'US DOLLAR 2.50',
+                context={'request': request})

--- a/djmoney/tests/test_settings.py
+++ b/djmoney/tests/test_settings.py
@@ -1,0 +1,3 @@
+override_currency_by_location = {
+    'HU': {'USD': ('US$', 'US DOLLAR ')},
+}


### PR DESCRIPTION
Adding a functionality where you can override currency signs by country code (location). `request` object should be available in the context and it should contain the `country_code`.

It has to be configured with the followings. Django settings ( CURRENCY_CONFIG_MODULE) which points to a python dictionary. 

An example dictionary looks like this.

```
override_currency_by_location = {
    'HU': {'USD': ('US$', 'USA DOLLAR ')},
}
```

```
override_currency_by_location = {
    country_code: {currency_code: (from_currency_sign, to_currency_sign)},
}
```
