### PR TITLE
VAL-4888 Currency Formatting for Next

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -147,22 +147,20 @@ class MoneyPatched(Money):
         return self.use_l10n
 
     def __unicode__(self):
-
-        if self.__use_l10n():
-            locale = self.__get_current_locale()
-            if locale:
-                return format_money(self, locale=locale)
-
-        return format_money(self)
+        return self.__str__()
 
     def __str__(self):
+        try:
+            decimal_places = self.decimal_places
+        except attributeError:
+            decimal_places == 2
 
         if self.__use_l10n():
             locale = self.__get_current_locale()
             if locale:
-                return format_money(self, locale=locale)
+                return format_money(self, locale=locale, decimal_places=decimal_places)
 
-        return format_money(self)
+        return format_money(self, decimal_places=decimal_places)
 
     def __repr__(self):
         # small fix for tests

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -152,7 +152,7 @@ class MoneyPatched(Money):
     def __str__(self):
         try:
             decimal_places = self.decimal_places
-        except attributeError:
+        except AttributeError:
             decimal_places == 2
 
         if self.__use_l10n():

--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -150,10 +150,7 @@ class MoneyPatched(Money):
         return self.__str__()
 
     def __str__(self):
-        try:
-            decimal_places = self.decimal_places
-        except AttributeError:
-            decimal_places == 2
+        decimal_places = getattr(self, "decimal_places", 2)
 
         if self.__use_l10n():
             locale = self.__get_current_locale()

--- a/djmoney/templatetags/djmoney.py
+++ b/djmoney/templatetags/djmoney.py
@@ -16,7 +16,7 @@ class MoneyLocalizeNode(template.Node):
         return "<MoneyLocalizeNode %r>" % self.money
 
     def __init__(self, money=None, amount=None, currency=None, use_l10n=None,
-                 var_name=None, no_decimal=False):
+                 var_name=None, decimal_places=2):
 
         if money and (amount or currency):
             raise Exception('You can define either "money" or the'
@@ -30,7 +30,7 @@ class MoneyLocalizeNode(template.Node):
 
         self.request = template.Variable('request')
         self.country_code = None
-        self.no_decimal = no_decimal
+        self.decimal_places = decimal_places
 
     @classmethod
     def handle_token(cls, parser, token, no_decimal=False):
@@ -44,7 +44,7 @@ class MoneyLocalizeNode(template.Node):
             return cls(money=parser.compile_filter(tokens[1]),
                        var_name=var_name,
                        use_l10n=use_l10n,
-                       no_decimal=no_decimal)
+                       decimal_places=0)
 
         # GET variable var_name
         if len(tokens) > 3:
@@ -107,6 +107,7 @@ class MoneyLocalizeNode(template.Node):
                                       'amount and currency.')
 
         money.use_l10n = self.use_l10n
+        money.decimal_places = self.decimal_places
 
         money = self._str_override_currency_sign(money)
 
@@ -119,7 +120,7 @@ class MoneyLocalizeNode(template.Node):
         return ''
 
     def _str_override_currency_sign(self, money):
-        str_money = unicode(format_money(money, decimal_places=0)) if self.no_decimal else unicode(money)
+        str_money = unicode(money)
         if hasattr(settings, 'CURRENCY_CONFIG_MODULE'):
             currency_config = importlib.import_module(settings.CURRENCY_CONFIG_MODULE)
             overrides = currency_config.override_currency_by_location

--- a/djmoney/tests/tags_tests.py
+++ b/djmoney/tests/tags_tests.py
@@ -121,3 +121,10 @@ class MoneyLocalizeTestCase(TestCase):
                     '{% load djmoney %}{% money_localize "2.5" "HUF" %}',
                     'Huf 2,50',
                     context={'request': request})
+
+    def testMoneyLocalizeNoDecimal(self):
+
+        self.assertTemplate(
+            '{% load djmoney %}{% money_localize_no_decimal money on %}',
+            '2 zł',
+            context={'money': Money(2.3, 'PLN')})


### PR DESCRIPTION
Add decimal place formatting to MoneyPatched

The previous changes broke the localized formatting. This brings the decimal place logic from the MoneyLocalizeNode object's render function to the MoneyPatched Object. This allows us to get the localization that we need.

![screen shot 2017-04-25 at 2 50 02 pm](https://cloud.githubusercontent.com/assets/7539345/25409704/ee8ee130-29c7-11e7-845c-26be28573f6b.png)
![screen shot 2017-04-25 at 2 49 53 pm](https://cloud.githubusercontent.com/assets/7539345/25409703/ee8a2988-29c7-11e7-9bd4-b62bd52fe3c6.png)
