### PR TITLE
AM-22 save money without decimal to new var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ djmoney/tests/testproject
 *\.egg
 *\.egg-info
 .cache
+venv

--- a/djmoney/templatetags/djmoney.py
+++ b/djmoney/templatetags/djmoney.py
@@ -40,12 +40,6 @@ class MoneyLocalizeNode(template.Node):
         var_name = None
         use_l10n = True
 
-        if no_decimal:
-            return cls(money=parser.compile_filter(tokens[1]),
-                       var_name=var_name,
-                       use_l10n=use_l10n,
-                       decimal_places=0)
-
         # GET variable var_name
         if len(tokens) > 3:
             if tokens[-2] == 'as':
@@ -63,18 +57,31 @@ class MoneyLocalizeNode(template.Node):
             # remove the already used data
             tokens.pop(-1)
 
+        if len(tokens) < 2:
+            raise TemplateSyntaxError('Wrong number of input data to the tag.')
+
+        create_args = {
+            'var_name': var_name,
+            'use_l10n': use_l10n,
+        }
+
         # GET variable money
         if len(tokens) == 2:
-            return cls(money=parser.compile_filter(tokens[1]),
-                       var_name=var_name, use_l10n=use_l10n)
+            create_args.update({
+                'money': parser.compile_filter(tokens[1]),
+            })
 
         # GET variable amount and currency
-        if len(tokens) == 3:
-            return cls(amount=parser.compile_filter(tokens[1]),
-                       currency=parser.compile_filter(tokens[2]),
-                       var_name=var_name, use_l10n=use_l10n)
+        elif len(tokens) == 3:
+            create_args.update({
+                'amount': parser.compile_filter(tokens[1]),
+                'currency': parser.compile_filter(tokens[2]),
+            })
 
-        raise TemplateSyntaxError('Wrong number of input data to the tag.')
+        if no_decimal:
+            create_args['decimal_places'] = 0
+
+        return cls(**create_args)
 
     def render(self, context):
 
@@ -167,10 +174,11 @@ def money_localize_no_decimal(parser, token):
     """
     Usage::
 
-        {% money_localize_no_decimal <money_object> %}
+        {% money_localize_no_decimal <money_object> [as var_name] %}
     Example:
 
         {% money_localize_no_decimal money_object %}
+        {% money_localize_no_decimal money_object as NEW_MONEY_OBJECT %}
 
     Return::
 

--- a/djmoney/tests/tags_tests.py
+++ b/djmoney/tests/tags_tests.py
@@ -128,3 +128,10 @@ class MoneyLocalizeTestCase(TestCase):
             '{% load djmoney %}{% money_localize_no_decimal money on %}',
             '2 zł',
             context={'money': Money(2.3, 'PLN')})
+
+    def testMoneyLocalizeNoDecimalAsVar(self):
+
+        self.assertTemplate(
+            '{% load djmoney %}{% money_localize_no_decimal money as NEW_M %}{{NEW_M}}',
+            '2 zł',
+            context={'money': Money(2.3, 'PLN')})


### PR DESCRIPTION
To be able to use the variable inside a `{% blocktrans %}`:
```
{% money_localize_no_decimal plan_sul_plus.yearly.per_month_amount_money as plus_price %}
{% blocktrans with price=plus_price %}Starting at {{ price }}/mo{% endblocktrans %}
```

This functionality exists on the original `{% money_localize %}` tag.

